### PR TITLE
WEKO addonにおいてインデックス作成が失敗する不具合の修正

### DIFF
--- a/addons/weko/client.py
+++ b/addons/weko/client.py
@@ -238,7 +238,7 @@ def post(connection, insert_index_id, stream, stream_size):
         'Content-Length': str(stream_size),
         'insert_index': str(insert_index_id)
     }
-    resp = connection.post_url(target, stream, headers=weko_headers)
+    resp = connection.post_url(target, stream, default_headers=weko_headers)
     logger.info(etree.tostring(resp))
     for index, elem in enumerate(resp.findall('.//{%s}content' % ATOM_NAMESPACE)):
         src = elem.attrib['src']
@@ -281,7 +281,7 @@ def create_index(connection, title_ja=None, title_en=None, relation=None):
         'Content-Type': 'text/xml',
         'Content-Length': str(len(stream)),
     }
-    root = connection.post_url(target, stream, headers=weko_headers)
+    root = connection.post_url(target, stream, default_headers=weko_headers)
     logger.info('Result: {}'.format(etree.tostring(root)))
     return index_id
 
@@ -314,7 +314,7 @@ def update_index(connection, index_id, title_ja=None, title_en=None, relation=No
         'Content-Type': 'text/xml',
         'Content-Length': str(len(stream)),
     }
-    root = connection.post_url(target, stream, headers=weko_headers)
+    root = connection.post_url(target, stream, default_headers=weko_headers)
     logger.info('Result: {}'.format(etree.tostring(root)))
 
 def create_import_xml(item_type, internal_item_type_id, uploaded_filenames, title, title_en, contributors):

--- a/addons/weko/tests/test_client.py
+++ b/addons/weko/tests/test_client.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+import mock
+from mock import call
+import requests
+from nose.tools import *  # noqa
+
+from tests.base import OsfTestCase
+
+import addons.weko.client as client
+
+fake_weko_last_index_id = 10
+fake_weko_host = 'http://localhost.weko.fake/'
+fake_weko_collection_url = '{0}collection'.format(fake_weko_host)
+fake_weko_servicedocument_url = "{0}servicedocument.php".format(fake_weko_host)
+
+fake_weko_service_document_xml = """
+<?xml version="1.0" encoding="utf-8"?>
+<service xmlns:dcterms="http://purl.org/dc/terms/" xmlns="http://www.w3.org/2007/app" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:sword="http://purl.org/net/sword/">
+  <sword:version>2</sword:version>
+  <sword:verbose>false</sword:verbose>
+  <sword:noOp>false</sword:noOp>
+  <sword:maxUploadSize>512000</sword:maxUploadSize>
+  <workspace>
+    <atom:title>WEKO</atom:title>
+    <collection href="{collection_url}">
+      <atom:title>Repository Review</atom:title>
+      <accept>application/zip</accept>
+      <dcterms:abstract>This is the review repository.</dcterms:abstract>
+      <sword:mediation>true</sword:mediation>
+      <sword:treatment>Deposited items(zip) will be treated as WEKO import file which contains any WEKO contents information, and will be imported to WEKO.</sword:treatment>
+      <sword:collectionPolicy>This collection accepts packages from any admin/moderator users on WEKO.</sword:collectionPolicy>
+      <sword:formatNamespace>WEKO</sword:formatNamespace>
+    </collection>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/metadata/dublin_core#">
+      <rdf:Description rdf:about="{weko_host}?action=repository_oaiore&amp;indexId={last_index_id}">
+        <dc:identifier>{last_index_id}</dc:identifier>
+        <dc:title>fake project title</dc:title>
+      </rdf:Description>
+    </rdf:RDF>
+  </workspace>
+</service>
+""".format(
+    weko_host=fake_weko_host,
+    collection_url=fake_weko_collection_url,
+    last_index_id=fake_weko_last_index_id
+).strip()
+
+fake_weko_create_index_post_result_xml = """
+<?xml version="1.0" encoding="utf-8"?>
+<result></result>
+""".strip()
+
+
+class MockResponse:
+    def __init__(self, content, status_code):
+        self.content = content
+        self.status_code = status_code
+
+
+mock_response_404 = MockResponse('404 not found', 404)
+
+
+def mock_requests_get(url, **kwargs):
+    if 'servicedocument.php' in url:
+        return MockResponse(fake_weko_service_document_xml, 200)
+
+    return mock_response_404
+
+
+def mock_requests_post(url, **kwargs):
+    if url == fake_weko_collection_url:
+        return MockResponse(fake_weko_create_index_post_result_xml, 200)
+
+    return mock_response_404
+
+
+class TestWEKOClient(OsfTestCase):
+    def setUp(self):
+        self.host = fake_weko_host
+        self.conn = client.connect_or_error(self.host)
+        super(TestWEKOClient, self).setUp()
+
+    def tearDown(self):
+        super(TestWEKOClient, self).tearDown()
+
+    @mock.patch('requests.get', side_effect=mock_requests_get)
+    @mock.patch('requests.post', side_effect=mock_requests_post)
+    def test_weko_create_index(self, get_req_mock, post_req_mock):
+        index_id = client.create_index(self.conn)
+        assert_equal(index_id, fake_weko_last_index_id + 1)


### PR DESCRIPTION
GRDM6552 に対応したPRです。
WEKO addonにおいてインデックス作成が失敗する不具合を修正しました。
WEKO addonの `client.py` の `Connection.post_url()` に渡す引数名が間違っていたのが原因でした。
再発防止のため、`post_url()` および `create_index()` の動作をチェックするユニットテストも追加しました。

#2 の開きなおし。