### PR TITLE
RDM Addonsの対応アドオン追加と、APIでの認証におけるRDM Addonsの設定の有効化

### DIFF
--- a/addons/azureblobstorage/views.py
+++ b/addons/azureblobstorage/views.py
@@ -16,6 +16,8 @@ from website.project.decorators import (
     must_be_addon_authorizer,
 )
 
+from admin.rdm_addons.decorators import must_be_rdm_addons_allowed
+
 SHORT_NAME = 'azureblobstorage'
 FULL_NAME = 'Azure Blob Storage'
 
@@ -58,6 +60,7 @@ def azureblobstorage_folder_list(node_addon, **kwargs):
     return node_addon.get_folders()
 
 @must_be_logged_in
+@must_be_rdm_addons_allowed(SHORT_NAME)
 def azureblobstorage_add_user_account(auth, **kwargs):
     """Verifies new external account credentials and adds to user's list"""
     try:

--- a/addons/base/generic_views.py
+++ b/addons/base/generic_views.py
@@ -16,10 +16,13 @@ from website.project.decorators import (
     must_be_valid_project
 )
 
+from admin.rdm_addons.decorators import must_be_rdm_addons_allowed
+
 def import_auth(addon_short_name, Serializer):
     @must_have_addon(addon_short_name, 'user')
     @must_have_addon(addon_short_name, 'node')
     @must_have_permission(permissions.WRITE)
+    @must_be_rdm_addons_allowed(addon_short_name)
     def _import_auth(auth, node_addon, user_addon, **kwargs):
         """Import add-on credentials from the currently logged-in user to a node.
         """

--- a/addons/base/tests/views.py
+++ b/addons/base/tests/views.py
@@ -8,8 +8,9 @@ from framework.auth import Auth
 from framework.exceptions import HTTPError
 from nose.tools import (assert_equal, assert_false, assert_in, assert_is_none,
                         assert_not_equal, assert_raises, assert_true)
-from osf_tests.factories import AuthUserFactory, ProjectFactory
+from osf_tests.factories import AuthUserFactory, ProjectFactory, InstitutionFactory
 from website.util import api_url_for, permissions, web_url_for
+from admin.rdm_addons.utils import get_rdm_addon_option
 
 
 class OAuthAddonAuthViewsTestCaseMixin(OAuthAddonTestCaseMixin):
@@ -34,6 +35,21 @@ class OAuthAddonAuthViewsTestCaseMixin(OAuthAddonTestCaseMixin):
                 continue
             assert value == provider_params[param]
 
+    def test_oauth_start_rdm_addons_denied(self):
+        institution = InstitutionFactory()
+        self.user.affiliated_institutions.add(institution)
+        self.user.save()
+        rdm_addon_option = get_rdm_addon_option(institution.id, self.ADDON_SHORT_NAME)
+        rdm_addon_option.is_allowed = False
+        rdm_addon_option.save()
+        url = api_url_for(
+            'oauth_connect',
+            service_name=self.ADDON_SHORT_NAME
+        )
+        res = self.app.get(url, auth=self.user.auth, expect_errors=True)
+        assert res.status_code == http.FORBIDDEN
+        assert_in('You are prohibited from using this add-on.', res.body)
+
     def test_oauth_finish(self):
         url = web_url_for(
             'oauth_callback',
@@ -45,6 +61,21 @@ class OAuthAddonAuthViewsTestCaseMixin(OAuthAddonTestCaseMixin):
         assert_equal(res.status_code, http.OK)
         name, args, kwargs = mock_callback.mock_calls[0]
         assert_equal(kwargs['user']._id, self.user._id)
+
+    def test_oauth_finish_rdm_addons_denied(self):
+        institution = InstitutionFactory()
+        self.user.affiliated_institutions.add(institution)
+        self.user.save()
+        rdm_addon_option = get_rdm_addon_option(institution.id, self.ADDON_SHORT_NAME)
+        rdm_addon_option.is_allowed = False
+        rdm_addon_option.save()
+        url = web_url_for(
+            'oauth_callback',
+            service_name=self.ADDON_SHORT_NAME
+        )
+        res = self.app.get(url, auth=self.user.auth, expect_errors=True)
+        assert res.status_code == http.FORBIDDEN
+        assert_in('You are prohibited from using this add-on.', res.body)
 
     def test_delete_external_account(self):
         url = api_url_for(

--- a/addons/dataverse/views.py
+++ b/addons/dataverse/views.py
@@ -25,6 +25,8 @@ from website.project.decorators import (
 from website.util import rubeus, api_url_for
 from website.util.sanitize import assert_clean
 
+from admin.rdm_addons.decorators import must_be_rdm_addons_allowed
+
 SHORT_NAME = 'dataverse'
 FULL_NAME = 'Dataverse'
 
@@ -75,6 +77,7 @@ def dataverse_user_config_get(auth, **kwargs):
 ## Config ##
 
 @must_be_logged_in
+@must_be_rdm_addons_allowed(SHORT_NAME)
 def dataverse_add_user_account(auth, **kwargs):
     """Verifies new external account credentials and adds to user's list"""
     user = auth.user

--- a/addons/gitlab/tests/test_views.py
+++ b/addons/gitlab/tests/test_views.py
@@ -8,7 +8,7 @@ import unittest
 
 from nose.tools import *  # noqa (PEP8 asserts)
 from tests.base import OsfTestCase, get_default_metaschema
-from osf_tests.factories import ProjectFactory, UserFactory, AuthUserFactory
+from osf_tests.factories import ProjectFactory, UserFactory, AuthUserFactory, InstitutionFactory
 
 from github3.repos.branch import Branch
 
@@ -24,6 +24,7 @@ from addons.gitlab.serializer import GitLabSerializer
 from addons.gitlab.utils import check_permissions
 from addons.gitlab.tests.utils import create_mock_gitlab, GitLabAddonTestCase
 from addons.gitlab.tests.factories import GitLabAccountFactory
+from admin.rdm_addons.utils import get_rdm_addon_option
 
 pytestmark = pytest.mark.django_db
 
@@ -82,6 +83,21 @@ class TestGitLabConfigViews(GitLabAddonTestCase, OAuthAddonConfigViewsTestCaseMi
             '{0}_repo_linked'.format(self.ADDON_SHORT_NAME)
         )
         mock_add_hook.assert_called_once()
+
+    def test_add_user_account_rdm_addons_denied(self):
+        institution = InstitutionFactory()
+        self.user.affiliated_institutions.add(institution)
+        self.user.save()
+        rdm_addon_option = get_rdm_addon_option(institution.id, self.ADDON_SHORT_NAME)
+        rdm_addon_option.is_allowed = False
+        rdm_addon_option.save()
+        url = self.project.api_url_for('gitlab_add_user_account')
+        rv = self.app.post_json(url,{
+            'access_key': 'aldkjf',
+            'secret_key': 'las'
+        }, auth=self.user.auth, expect_errors=True)
+        assert_equal(rv.status_int, http.FORBIDDEN)
+        assert_in('You are prohibited from using this add-on.', rv.body)
 
 
 # TODO: Test remaining CRUD methods

--- a/addons/gitlab/views.py
+++ b/addons/gitlab/views.py
@@ -24,6 +24,8 @@ from website.project.decorators import (
 )
 from website.util import api_url_for
 
+from admin.rdm_addons.decorators import must_be_rdm_addons_allowed
+
 
 logger = logging.getLogger(__name__)
 
@@ -85,6 +87,7 @@ def gitlab_user_config_get(auth, **kwargs):
     }, http.OK
 
 @must_be_logged_in
+@must_be_rdm_addons_allowed(SHORT_NAME)
 def gitlab_add_user_account(auth, **kwargs):
     """Verifies new external account credentials and adds to user's list"""
 

--- a/addons/nextcloud/views.py
+++ b/addons/nextcloud/views.py
@@ -18,6 +18,8 @@ from addons.nextcloud.models import NextcloudProvider
 from addons.nextcloud.serializer import NextcloudSerializer
 from addons.nextcloud import settings
 
+from admin.rdm_addons.decorators import must_be_rdm_addons_allowed
+
 SHORT_NAME = 'nextcloud'
 FULL_NAME = 'Nextcloud'
 
@@ -38,6 +40,7 @@ nextcloud_deauthorize_node = generic_views.deauthorize_node(
 ## Config ##
 
 @must_be_logged_in
+@must_be_rdm_addons_allowed(SHORT_NAME)
 def nextcloud_add_user_account(auth, **kwargs):
     """
         Verifies new external account credentials and adds to user's list

--- a/addons/owncloud/tests/test_views.py
+++ b/addons/owncloud/tests/test_views.py
@@ -5,6 +5,8 @@ import pytest
 
 import httplib as http
 
+from osf_tests.factories import InstitutionFactory
+
 from addons.base.tests.views import (
     OAuthAddonAuthViewsTestCaseMixin, OAuthAddonConfigViewsTestCaseMixin
 )
@@ -12,6 +14,7 @@ from addons.owncloud.models import OwnCloudProvider
 from tests.base import OsfTestCase
 from addons.owncloud.serializer import OwnCloudSerializer
 from addons.owncloud.tests.utils import OwnCloudAddonTestCase
+from admin.rdm_addons.utils import get_rdm_addon_option
 
 pytestmark = pytest.mark.django_db
 
@@ -64,3 +67,18 @@ class TestConfigViews(OwnCloudAddonTestCase, OAuthAddonConfigViewsTestCaseMixin,
             self.user,
         )
         assert_equal(serialized, res.json['result'])
+
+    def test_add_user_account_rdm_addons_denied(self):
+        institution = InstitutionFactory()
+        self.user.affiliated_institutions.add(institution)
+        self.user.save()
+        rdm_addon_option = get_rdm_addon_option(institution.id, self.ADDON_SHORT_NAME)
+        rdm_addon_option.is_allowed = False
+        rdm_addon_option.save()
+        url = self.project.api_url_for('owncloud_add_user_account')
+        rv = self.app.post_json(url,{
+            'access_key': 'aldkjf',
+            'secret_key': 'las'
+        }, auth=self.user.auth, expect_errors=True)
+        assert_equal(rv.status_int, http.FORBIDDEN)
+        assert_in('You are prohibited from using this add-on.', rv.body)

--- a/addons/owncloud/views.py
+++ b/addons/owncloud/views.py
@@ -18,6 +18,8 @@ from addons.owncloud.models import OwnCloudProvider
 from addons.owncloud.serializer import OwnCloudSerializer
 from addons.owncloud import settings
 
+from admin.rdm_addons.decorators import must_be_rdm_addons_allowed
+
 SHORT_NAME = 'owncloud'
 FULL_NAME = 'OwnCloud'
 
@@ -38,6 +40,7 @@ owncloud_deauthorize_node = generic_views.deauthorize_node(
 ## Config ##
 
 @must_be_logged_in
+@must_be_rdm_addons_allowed(SHORT_NAME)
 def owncloud_add_user_account(auth, **kwargs):
     """
         Verifies new external account credentials and adds to user's list

--- a/addons/s3/views.py
+++ b/addons/s3/views.py
@@ -16,6 +16,8 @@ from website.project.decorators import (
     must_be_addon_authorizer,
 )
 
+from admin.rdm_addons.decorators import must_be_rdm_addons_allowed
+
 SHORT_NAME = 's3'
 FULL_NAME = 'Amazon S3'
 
@@ -58,6 +60,7 @@ def s3_folder_list(node_addon, **kwargs):
     return node_addon.get_folders()
 
 @must_be_logged_in
+@must_be_rdm_addons_allowed(SHORT_NAME)
 def s3_add_user_account(auth, **kwargs):
     """Verifies new external account credentials and adds to user's list"""
     try:

--- a/addons/s3compat/tests/test_view.py
+++ b/addons/s3compat/tests/test_view.py
@@ -9,7 +9,7 @@ import pytest
 
 from framework.auth import Auth
 from tests.base import OsfTestCase, get_default_metaschema
-from osf_tests.factories import ProjectFactory, AuthUserFactory
+from osf_tests.factories import ProjectFactory, AuthUserFactory, InstitutionFactory
 
 from addons.base.tests.views import (
     OAuthAddonConfigViewsTestCaseMixin
@@ -18,6 +18,7 @@ from addons.s3compat.tests.utils import S3CompatAddonTestCase
 from addons.s3compat.utils import validate_bucket_name
 import addons.s3compat.settings as s3compat_settings
 from website.util import api_url_for
+from admin.rdm_addons.utils import get_rdm_addon_option
 
 pytestmark = pytest.mark.django_db
 
@@ -89,6 +90,21 @@ class TestS3CompatViews(S3CompatAddonTestCase, OAuthAddonConfigViewsTestCaseMixi
         }, auth=self.user.auth, expect_errors=True)
         assert_equals(rv.status_int, http.BAD_REQUEST)
         assert_in('The host is not available.', rv.body)
+
+    def test_s3compat_settings_rdm_addons_denied(self):
+        institution = InstitutionFactory()
+        self.user.affiliated_institutions.add(institution)
+        self.user.save()
+        rdm_addon_option = get_rdm_addon_option(institution.id, self.ADDON_SHORT_NAME)
+        rdm_addon_option.is_allowed = False
+        rdm_addon_option.save()
+        url = self.project.api_url_for('s3compat_add_user_account')
+        rv = self.app.post_json(url,{
+            'access_key': 'aldkjf',
+            'secret_key': 'las'
+        }, auth=self.user.auth, expect_errors=True)
+        assert_equal(rv.status_int, http.FORBIDDEN)
+        assert_in('You are prohibited from using this add-on.', rv.body)
 
     def test_s3compat_set_bucket_no_settings(self):
         user = AuthUserFactory()

--- a/addons/s3compat/views.py
+++ b/addons/s3compat/views.py
@@ -17,6 +17,8 @@ from website.project.decorators import (
     must_be_addon_authorizer,
 )
 
+from admin.rdm_addons.decorators import must_be_rdm_addons_allowed
+
 
 SHORT_NAME = 's3compat'
 FULL_NAME = 'S3 Compatible Storage'
@@ -60,6 +62,7 @@ def s3compat_folder_list(node_addon, **kwargs):
     return node_addon.get_folders()
 
 @must_be_logged_in
+@must_be_rdm_addons_allowed(SHORT_NAME)
 def s3compat_add_user_account(auth, **kwargs):
     """Verifies new external account credentials and adds to user's list"""
     try:

--- a/addons/swift/views.py
+++ b/addons/swift/views.py
@@ -17,6 +17,8 @@ from website.project.decorators import (
     must_be_addon_authorizer,
 )
 
+from admin.rdm_addons.decorators import must_be_rdm_addons_allowed
+
 SHORT_NAME = 'swift'
 FULL_NAME = 'OpenStack Swift'
 
@@ -59,6 +61,7 @@ def swift_folder_list(node_addon, **kwargs):
     return node_addon.get_folders()
 
 @must_be_logged_in
+@must_be_rdm_addons_allowed(SHORT_NAME)
 def swift_add_user_account(auth, **kwargs):
     """Verifies new external account credentials and adds to user's list"""
     try:

--- a/addons/weko/views.py
+++ b/addons/weko/views.py
@@ -32,17 +32,21 @@ from website.util.sanitize import assert_clean
 from website.oauth.utils import get_service
 from website.oauth.signals import oauth_complete
 
+from admin.rdm_addons.decorators import must_be_rdm_addons_allowed
+
 logger = logging.getLogger('addons.weko.views')
 
 SHORT_NAME = 'weko'
 FULL_NAME = 'WEKO'
 
 @must_be_logged_in
+@must_be_rdm_addons_allowed(SHORT_NAME)
 def weko_oauth_connect(repoid, auth):
     service = get_service(SHORT_NAME)
     return redirect(service.get_repo_auth_url(repoid))
 
 @must_be_logged_in
+@must_be_rdm_addons_allowed(SHORT_NAME)
 def weko_oauth_callback(repoid, auth):
     user = auth.user
     provider = get_service(SHORT_NAME)
@@ -138,6 +142,7 @@ def weko_set_config(node_addon, user_addon, auth, **kwargs):
     return {'index': index.title}, http.OK
 
 @must_be_logged_in
+@must_be_rdm_addons_allowed(SHORT_NAME)
 def weko_add_user_account(auth, **kwargs):
     """Verifies new external account credentials and adds to user's list"""
     try:

--- a/admin/base/settings/defaults.py
+++ b/admin/base/settings/defaults.py
@@ -161,6 +161,15 @@ MIGRATION_MODULES = {
     'addons_onedrive': None
 }
 
+UNSUPPORTED_FORCE_TO_USE_ADDONS = [
+    'swift',
+    'weko',
+    's3compat',
+    'nextcloud',
+    'gitlab',
+    'onedrive'
+]
+
 USE_TZ = True
 TIME_ZONE = 'UTC'
 

--- a/admin/base/settings/defaults.py
+++ b/admin/base/settings/defaults.py
@@ -162,6 +162,7 @@ MIGRATION_MODULES = {
 }
 
 UNSUPPORTED_FORCE_TO_USE_ADDONS = [
+    'azureblobstorage',
     'swift',
     'weko',
     's3compat',

--- a/admin/base/settings/defaults.py
+++ b/admin/base/settings/defaults.py
@@ -125,9 +125,13 @@ INSTALLED_APPS = (
     'addons.owncloud',
     'addons.s3',
     'addons.zotero',
-    #     'addons.swift',
-    #     'addons.azureblobstorage',
-    #     'addons.weko',
+    'addons.swift',
+    'addons.azureblobstorage',
+    'addons.weko',
+    'addons.s3compat',
+    'addons.nextcloud',
+    'addons.gitlab',
+    'addons.onedrive'
 )
 
 MIGRATION_MODULES = {
@@ -148,9 +152,13 @@ MIGRATION_MODULES = {
     'addons_owncloud': None,
     'addons_s3': None,
     'addons_zotero': None,
-    #    'addons.swift': None,
-    #    'addons.azureblobstorage': None,
-    #    'addons.weko': None,
+    'addons_swift': None,
+    'addons_azureblobstorage': None,
+    'addons_weko': None,
+    'addons_s3compat': None,
+    'addons_nextcloud': None,
+    'addons_gitlab': None,
+    'addons_onedrive': None
 }
 
 USE_TZ = True

--- a/admin/rdm_addons/decorators.py
+++ b/admin/rdm_addons/decorators.py
@@ -1,0 +1,40 @@
+import functools
+import httplib
+
+from framework.exceptions import HTTPError
+
+from admin.rdm_addons.utils import get_rdm_addon_option
+from admin.rdm.utils import get_institution_id
+
+
+def must_be_rdm_addons_allowed(addon_short_name=None):
+    def wrapper(func):
+        @functools.wraps(func)
+        def wrapped(*args, **kwargs):
+            if 'auth' not in kwargs:
+                raise HTTPError(httplib.UNAUTHORIZED)
+
+            if addon_short_name is None:
+                if 'service_name' not in kwargs:
+                    raise HTTPError(httplib.BAD_REQUEST)
+                else:
+                    _addon_short_name = kwargs['service_name']
+            else:
+                _addon_short_name = addon_short_name
+
+            auth = kwargs['auth']
+            institution_id = get_institution_id(auth.user)
+
+            rdm_addon_option = get_rdm_addon_option(institution_id, _addon_short_name)
+
+            if not rdm_addon_option.is_allowed:
+                return {
+                   'message': ('Unable to access account.\n'
+                               'You are prohibited from using this add-on.')
+                }, httplib.FORBIDDEN
+
+            return func(*args, **kwargs)
+
+        return wrapped
+
+    return wrapper

--- a/admin/rdm_addons/decorators.py
+++ b/admin/rdm_addons/decorators.py
@@ -1,8 +1,11 @@
 import functools
 import httplib
 
+from flask import request
+
 from framework.exceptions import HTTPError
 
+from website.util.sanitize import escape_html
 from admin.rdm_addons.utils import get_rdm_addon_option
 from admin.rdm.utils import get_institution_id
 
@@ -38,3 +41,28 @@ def must_be_rdm_addons_allowed(addon_short_name=None):
         return wrapped
 
     return wrapper
+
+
+def must_be_rdm_addons_allowed_all(func):
+    @functools.wraps(func)
+    def wrapped(*args, **kwargs):
+        if 'auth' not in kwargs:
+            return func(*args, **kwargs)
+
+        auth = kwargs['auth']
+        institution_id = get_institution_id(auth.user)
+
+        config = escape_html(request.get_json())
+
+        for addon_name, enabled in config.iteritems():
+            rdm_addon_option = get_rdm_addon_option(institution_id, addon_name)
+
+            if not rdm_addon_option.is_allowed:
+                return {
+                           'message': ('Unable to access account.\n'
+                                       'You are prohibited from using this add-on.')
+                       }, httplib.FORBIDDEN
+
+        return func(*args, **kwargs)
+
+    return wrapped

--- a/admin/rdm_addons/decorators.py
+++ b/admin/rdm_addons/decorators.py
@@ -1,13 +1,9 @@
 import functools
 import httplib
 
-from flask import request
+from framework.exceptions import HTTPError, PermissionsError
 
-from framework.exceptions import HTTPError
-
-from website.util.sanitize import escape_html
-from admin.rdm_addons.utils import get_rdm_addon_option
-from admin.rdm.utils import get_institution_id
+from admin.rdm_addons.utils import validate_rdm_addons_allowed
 
 
 def must_be_rdm_addons_allowed(addon_short_name=None):
@@ -17,52 +13,15 @@ def must_be_rdm_addons_allowed(addon_short_name=None):
             if 'auth' not in kwargs:
                 raise HTTPError(httplib.UNAUTHORIZED)
 
-            if addon_short_name is None:
-                if 'service_name' not in kwargs:
-                    raise HTTPError(httplib.BAD_REQUEST)
-                else:
-                    _addon_short_name = kwargs['service_name']
-            else:
-                _addon_short_name = addon_short_name
-
             auth = kwargs['auth']
-            institution_id = get_institution_id(auth.user)
 
-            rdm_addon_option = get_rdm_addon_option(institution_id, _addon_short_name)
-
-            if not rdm_addon_option.is_allowed:
-                return {
-                   'message': ('Unable to access account.\n'
-                               'You are prohibited from using this add-on.')
-                }, httplib.FORBIDDEN
+            try:
+                validate_rdm_addons_allowed(auth, addon_short_name)
+            except PermissionsError as e:
+                return {'message_long': e.message}, httplib.FORBIDDEN
 
             return func(*args, **kwargs)
 
         return wrapped
 
     return wrapper
-
-
-def must_be_rdm_addons_allowed_all(func):
-    @functools.wraps(func)
-    def wrapped(*args, **kwargs):
-        if 'auth' not in kwargs:
-            return func(*args, **kwargs)
-
-        auth = kwargs['auth']
-        institution_id = get_institution_id(auth.user)
-
-        config = escape_html(request.get_json())
-
-        for addon_name, enabled in config.iteritems():
-            rdm_addon_option = get_rdm_addon_option(institution_id, addon_name)
-
-            if not rdm_addon_option.is_allowed:
-                return {
-                           'message': ('Unable to access account.\n'
-                                       'You are prohibited from using this add-on.')
-                       }, httplib.FORBIDDEN
-
-        return func(*args, **kwargs)
-
-    return wrapped

--- a/admin/rdm_addons/utils.py
+++ b/admin/rdm_addons/utils.py
@@ -10,6 +10,7 @@ from osf.models import RdmAddonOption, RdmAddonNoInstitutionOption
 from website import settings
 from admin.base.settings import BASE_DIR
 from admin.rdm.utils import get_institution_id
+from admin.base.settings import UNSUPPORTED_FORCE_TO_USE_ADDONS
 
 def get_institusion_settings_template(config):
     """get template file settings"""
@@ -29,6 +30,7 @@ def get_addon_template_config(config, user):
         'institution_settings_template': get_institusion_settings_template(config),
         'is_enabled': user_addon is not None,
         'addon_icon_url': reverse('addons:icon', args=[config.short_name, config.icon]),
+        'is_supported_force_to_use': config.short_name not in UNSUPPORTED_FORCE_TO_USE_ADDONS,
     }
     ret.update(user_addon.to_json(user) if user_addon else {})
     return ret

--- a/admin/rdm_addons/utils.py
+++ b/admin/rdm_addons/utils.py
@@ -4,6 +4,8 @@ import os
 
 from django.urls import reverse
 
+from framework.exceptions import PermissionsError
+
 from osf.models import RdmAddonOption, RdmAddonNoInstitutionOption
 from website import settings
 from admin.base.settings import BASE_DIR
@@ -73,3 +75,10 @@ def update_with_rdm_addon_settings(addon_setting, user):
         addon['is_forced'] = rdm_addon_option.is_forced
         addon['has_external_accounts'] = rdm_addon_option.external_accounts.exists()
         addon['has_user_external_accounts'] = user.external_accounts.filter(provider=addon_name).exists()
+
+def validate_rdm_addons_allowed(auth, addon_name):
+    institution_id = get_institution_id(auth.user)
+    rdm_addon_option = get_rdm_addon_option(institution_id, addon_name)
+    if not rdm_addon_option.is_allowed:
+        raise PermissionsError('Unable to access account.\n'
+                               'You are prohibited from using this add-on.')

--- a/admin/templates/rdm_addons/addon_list.html
+++ b/admin/templates/rdm_addons/addon_list.html
@@ -41,6 +41,7 @@
 
                     {% if enable_force %}
                         <td class="is_forced">
+                            {% if addon.is_supported_force_to_use %}
                             <div class="checkbox">
                                 <label>
                                     <input type="checkbox"
@@ -49,6 +50,7 @@
                                         {% if addon.option.is_forced %}checked{% endif %}> Force to use
                                 </label>
                             </div>
+                            {% endif %}
                         </td>
                     {% endif %}
                     </tr>

--- a/admin/templates/rdm_addons/addons/institution_settings_default.html
+++ b/admin/templates/rdm_addons/addons/institution_settings_default.html
@@ -6,10 +6,13 @@
     <h4 class="addon-title">
       <img class="addon-icon" src="{{ addon.addon_icon_url }}">
       <span data-bind="text:properName">{# addon.addon_full_name #}</span>
+      {% if addon.is_supported_force_to_use %}
       <small>
         <a data-bind="click: connectAccount" class="pull-right text-primary">Connect or Reauthorize Account</a>
       </small>
+      {% endif %}
     </h4>
+    {% if addon.is_supported_force_to_use %}
     <div class="addon-auth-table" id="{{ addon.addon_short_name }}-header">
         <!-- ko foreach: accounts -->
         <a data-bind="click: $root.askDisconnect.bind($root)" class="text-danger pull-right default-authorized-by">Disconnect Account</a>
@@ -46,4 +49,5 @@
     <div class="help-block">
         <p data-bind="html: message, attr: { class: messageClass }"></p>
     </div>
+    {% endif %}
 </div>

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -907,7 +907,7 @@ class TestProjectViews(OsfTestCase):
             assert_equal(res.status_code, 200, route)
             assert_in('This project is a withdrawn registration of', res.body, route)
 
-    # TODO: Use mock add-on
+    # TODO: Use mock add-on (same as a TODO of TestAddonUserViews)
     def test_choose_addons_add(self):
         url = self.project.api_url_for('node_choose_addons')
         self.app.post_json(

--- a/website/oauth/views.py
+++ b/website/oauth/views.py
@@ -11,6 +11,8 @@ from website.oauth.utils import get_service
 from website.oauth.signals import oauth_complete
 from requests.exceptions import ConnectionError
 
+from admin.rdm_addons.decorators import must_be_rdm_addons_allowed
+
 
 @must_be_logged_in
 def oauth_disconnect(external_account_id, auth):
@@ -35,6 +37,7 @@ def oauth_disconnect(external_account_id, auth):
     user.save()
 
 @must_be_logged_in
+@must_be_rdm_addons_allowed()
 def oauth_connect(service_name, auth):
     service = get_service(service_name)
 
@@ -42,6 +45,7 @@ def oauth_connect(service_name, auth):
 
 
 @must_be_logged_in
+@must_be_rdm_addons_allowed()
 def osf_oauth_callback(service_name, auth):
     user = auth.user
     provider = get_service(service_name)

--- a/website/oauth/views.py
+++ b/website/oauth/views.py
@@ -12,8 +12,6 @@ from website.oauth.signals import oauth_complete
 from requests.exceptions import ConnectionError
 from admin.rdm_addons.utils import validate_rdm_addons_allowed
 
-from admin.rdm_addons.decorators import must_be_rdm_addons_allowed
-
 
 @must_be_logged_in
 def oauth_disconnect(external_account_id, auth):
@@ -53,7 +51,6 @@ def oauth_connect(service_name, auth):
 
 
 @must_be_logged_in
-@must_be_rdm_addons_allowed()
 def osf_oauth_callback(service_name, auth):
     try:
         validate_rdm_addons_allowed(auth, service_name)

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -32,7 +32,7 @@ from website.util.time import throttle_period_expired
 from website.util import api_v2_url, web_url_for, paths
 from website.util.sanitize import escape_html
 from addons.base import utils as addon_utils
-from admin.rdm_addons.decorators import must_be_rdm_addons_allowed_all
+from admin.rdm_addons.utils import validate_rdm_addons_allowed
 
 logger = logging.getLogger(__name__)
 
@@ -464,11 +464,20 @@ def collect_user_config_js(addon_configs):
 
 
 @must_be_logged_in
-@must_be_rdm_addons_allowed_all
 def user_choose_addons(**kwargs):
     auth = kwargs['auth']
-    json_data = escape_html(request.get_json())
-    auth.user.config_addons(json_data, auth)
+    config = escape_html(request.get_json())
+    try:
+        for addon_name, enabled in config.iteritems():
+            if enabled:
+                validate_rdm_addons_allowed(auth, addon_name)
+    except PermissionsError as e:
+        raise HTTPError(
+            http.FORBIDDEN,
+            data=dict(message_long=e.message)
+        )
+
+    auth.user.config_addons(config, auth)
 
 @must_be_logged_in
 def user_choose_mailing_lists(auth, **kwargs):

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -32,6 +32,7 @@ from website.util.time import throttle_period_expired
 from website.util import api_v2_url, web_url_for, paths
 from website.util.sanitize import escape_html
 from addons.base import utils as addon_utils
+from admin.rdm_addons.decorators import must_be_rdm_addons_allowed_all
 
 logger = logging.getLogger(__name__)
 
@@ -463,6 +464,7 @@ def collect_user_config_js(addon_configs):
 
 
 @must_be_logged_in
+@must_be_rdm_addons_allowed_all
 def user_choose_addons(**kwargs):
     auth = kwargs['auth']
     json_data = escape_html(request.get_json())

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -52,6 +52,7 @@ from addons.wiki.utils import serialize_wiki_widget
 from addons.dataverse.utils import serialize_dataverse_widget
 from addons.forward.utils import serialize_forward_widget
 from addons.jupyterhub.utils import serialize_jupyterhub_widget
+from admin.rdm_addons.decorators import must_be_rdm_addons_allowed_all
 
 r_strip_html = lambda collection: rapply(collection, strip_html)
 logger = logging.getLogger(__name__)
@@ -401,6 +402,7 @@ def collect_node_config_js(addons):
 
 @must_have_permission(WRITE)
 @must_not_be_registration
+@must_be_rdm_addons_allowed_all
 def node_choose_addons(auth, node, **kwargs):
     node.config_addons(request.json, auth)
 


### PR DESCRIPTION
GRDM7015 に対応したPRです。

RDM Addonsにおいて、以下のアドオンについてallow機能を対応しました。
- swift
- azureblobstorage
- weko
- s3compat
- nextcloud
- gitlab
- onedrive

上のアドオンらは、Force to useには対応していません。Force to use非対応のアドオンは、AdminのRDM Addonsページにおける、"Connect or Reauthorize Account" リンクおよび "Force to use" チェックボックスを非表示にしています。  
Force to use 非対応のアドオンは、`admin/base/settings/defaults.py` の `UNSUPPORTED_FORCE_TO_USE_ADDONS` で列挙しています。

また、API経由でも、RDM Addonsで非許可に設定したアドオンを有効化できないよう修正しました。