### PR TITLE
RDM独自アドオンのコードのflake8エラー修正

### DIFF
--- a/addons/azureblobstorage/models.py
+++ b/addons/azureblobstorage/models.py
@@ -67,7 +67,7 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
         # as that's all we want to be linkable on a node.
         try:
             containers = get_container_names(self)
-        except:
+        except Exception:
             raise exceptions.InvalidAuthError()
 
         return [

--- a/addons/azureblobstorage/utils.py
+++ b/addons/azureblobstorage/utils.py
@@ -27,7 +27,7 @@ def get_container_names(node_settings):
 def validate_container_name(name):
     """Make sure the container name conforms to Azure's expectations
     """
-    label = '[a-z0-9]+(?:[a-z0-9\-]*[a-z0-9])*'
+    label = '[a-z0-9]+(?:[a-z0-9-]*[a-z0-9])*'
     validate_name = re.compile('^' + label + '$')
     return (
         len(name) >= 3 and len(name) <= 63 and bool(validate_name.match(name))

--- a/addons/azureblobstorage/utils.py
+++ b/addons/azureblobstorage/utils.py
@@ -27,7 +27,7 @@ def get_container_names(node_settings):
 def validate_container_name(name):
     """Make sure the container name conforms to Azure's expectations
     """
-    label = '[a-z0-9]+(?:[a-z0-9-]*[a-z0-9])*'
+    label = r'[a-z0-9]+(?:[a-z0-9\-]*[a-z0-9])*'
     validate_name = re.compile('^' + label + '$')
     return (
         len(name) >= 3 and len(name) <= 63 and bool(validate_name.match(name))

--- a/addons/nextcloud/models.py
+++ b/addons/nextcloud/models.py
@@ -169,7 +169,7 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
 
         ret = []
         for item in c.list(path):
-            if item.file_type is 'dir':
+            if item.file_type == 'dir':
                 ret.append({
                     'addon': 'nextcloud',
                     'path': item.path,

--- a/addons/nextcloud/serializer.py
+++ b/addons/nextcloud/serializer.py
@@ -24,7 +24,7 @@ class NextcloudSerializer(StorageAddonSerializer):
             oc.login(provider.username, provider.password)
             oc.logout()
             return True
-        except:
+        except Exception:
             return False
 
     @property

--- a/addons/s3compat/models.py
+++ b/addons/s3compat/models.py
@@ -65,7 +65,7 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
         # as that's all we want to be linkable on a node.
         try:
             buckets = get_bucket_names(self)
-        except:
+        except Exception:
             raise exceptions.InvalidAuthError()
 
         return [

--- a/addons/s3compat/utils.py
+++ b/addons/s3compat/utils.py
@@ -60,9 +60,9 @@ def validate_bucket_name(name):
     http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html#bucketnamingrules
     The laxer rules for US East (N. Virginia) are not supported.
     """
-    label = '[a-z0-9]+(?:[a-z0-9\-]*[a-z0-9])?'
+    label = r'[a-z0-9]+(?:[a-z0-9\-]*[a-z0-9])?'
     validate_name = re.compile('^' + label + '(?:\\.' + label + ')*$')
-    is_ip_address = re.compile('^[0-9]+(?:\.[0-9]+){3}$')
+    is_ip_address = re.compile(r'^[0-9]+(?:\.[0-9]+){3}$')
     return (
         len(name) >= 3 and len(name) <= 63 and bool(validate_name.match(name)) and not bool(is_ip_address.match(name))
     )

--- a/addons/swift/models.py
+++ b/addons/swift/models.py
@@ -78,7 +78,7 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
     def get_folders(self, **kwargs):
         try:
             containers = get_container_names(self)
-        except:
+        except Exception:
             raise exceptions.InvalidAuthError()
 
         return [


### PR DESCRIPTION
GRDM #8149 に対応したPRです。

flake8に関する以下のエラーを修正しました。

```
addons/azureblobstorage/models.py:70:9: E722 do not use bare 'except'
addons/azureblobstorage/utils.py:30:33: W605 invalid escape sequence '\-'
addons/nextcloud/models.py:172:16: F632 use ==/!= to compare str, bytes, and int literals
addons/nextcloud/serializer.py:27:9: E722 do not use bare 'except'
addons/s3compat/models.py:68:9: E722 do not use bare 'except'
addons/s3compat/utils.py:63:33: W605 invalid escape sequence '\-'
addons/s3compat/utils.py:65:43: W605 invalid escape sequence '\.'
addons/swift/models.py:81:9: E722 do not use bare 'except'
```

addons/ 配下では以下のエラーが残っています。

```
addons/base/models.py:681:27: W504 line break after binary operator
addons/base/models.py:682:35: W504 line break after binary operator
addons/base/models.py:692:27: W504 line break after binary operator
addons/base/serializer.py:74:41: W504 line break after binary operator
addons/base/views.py:406:79: W504 line break after binary operator
addons/base/views.py:407:57: W504 line break after binary operator
addons/base/views.py:408:47: W504 line break after binary operator
addons/bitbucket/models.py:375:99: W504 line break after binary operator
addons/bitbucket/views.py:105:51: W504 line break after binary operator
addons/box/models.py:201:89: W504 line break after binary operator
addons/github/models.py:361:99: W504 line break after binary operator
addons/github/utils.py:128:44: W504 line break after binary operator
addons/github/utils.py:129:49: W504 line break after binary operator
addons/github/utils.py:130:20: W504 line break after binary operator
addons/github/views.py:101:48: W504 line break after binary operator
addons/gitlab/models.py:321:99: W504 line break after binary operator
addons/gitlab/utils.py:100:66: W504 line break after binary operator
addons/gitlab/utils.py:113:44: W504 line break after binary operator
addons/gitlab/utils.py:114:49: W504 line break after binary operator
addons/gitlab/utils.py:115:20: W504 line break after binary operator
addons/gitlab/views.py:180:48: W504 line break after binary operator
addons/gitlab/views.py:181:48: W504 line break after binary operator
addons/osfstorage/views.py:356:13: E117 over-indented
addons/owncloud/models.py:175:16: F632 use ==/!= to compare str, bytes, and int literals
addons/s3/utils.py:45:33: W605 invalid escape sequence '\-'
addons/s3/utils.py:47:43: W605 invalid escape sequence '\.'
addons/wiki/views.py:188:53: W504 line break after binary operator
addons/zotero/provider.py:104:20: F632 use ==/!= to compare str, bytes, and int literals
```

`do not use bare 'except'` エラーは単純に `expect Exception` としてすべてのExceptionを明示的に受けることで回避しています。あまり行儀よくはありませんが、本家でもやっています。
https://github.com/RCOSDP/RDM-osf.io/blob/nii-mergework-201901/addons/s3/models.py#L88

utils.py のvalidationのregexの修正は、[S3](https://github.com/CenterForOpenScience/osf.io/blob/develop/addons/s3/utils.py#L40)に合わせて`r`付けただけです。
（labelの`[a-z0-9\-]`は`[a-z0-9-]`が正しい気がしますが、本家に合わせてます）