### PR TITLE
RDM独自アドオンのエラーメッセージ定義を追加

### DIFF
--- a/website/static/js/osfLanguage.js
+++ b/website/static/js/osfLanguage.js
@@ -108,6 +108,32 @@ module.exports = {
                         $osf.osfSupportLink(),
             submitSettingsSuccess : 'Folder Successfully linked',
         },
+        swift: {
+            authError: 'Could not connect to OpenStack Swift at this time. Please try again later.',
+            userSettingsError: 'Could not retrieve settings. Please refresh the page or ' +
+                'contact ' + $osf.osfSupportLink() + ' if the problem persists.',
+        },
+        azureblobstorage: {
+            authError: 'Could not connect to Azure Blob Storage at this time. Please try again later.',
+            userSettingsError: 'Could not retrieve settings. Please refresh the page or ' +
+                'contact ' + $osf.osfSupportLink() + ' if the problem persists.',
+        },
+        weko: {
+            authError: 'Could not connect to WEKO at this time. Please try again later.',
+            userSettingsError: 'Could not retrieve settings. Please refresh the page or ' +
+                'contact ' + $osf.osfSupportLink() + ' if the problem persists.',
+        },
+        s3compat: {
+            authError: 'Could not connect to S3 Compatible Storage at this time. Please try again later.',
+            userSettingsError: 'Could not retrieve settings. Please refresh the page or ' +
+                'contact ' + $osf.osfSupportLink() + ' if the problem persists.',
+        },
+        nextcloud: {
+            authError: 'Invalid Nextcloud server',
+            authInvalid: 'Invalid credentials. Please enter a valid username and password.',
+            userSettingsError: 'Could not retrieve settings. Please refresh the page or ' +
+                'contact ' + $osf.osfSupportLink() + ' if the problem persists.',
+        },
     },
     apiOauth2Application: {
         discardUnchanged: 'Are you sure you want to discard your unsaved changes?',


### PR DESCRIPTION
## Purpose

Webクライアント側で利用するRDM独自アドオンのエラーメッセージ定義が漏れていたため、追加しました。

## Changes

-  `website/static/js/osfLanguage.js` にswift, azureblobstorage, weko, s3compat, nextcloudのエラーメッセージ定義を追加

## QA Notes

None

## Side Effects

None

## Ticket

GRDM-9217
