### PR TITLE
Fix japanese text with english in IQB-RIMS Addon admin page

### DIFF
--- a/admin/templates/rdm_addons/addons/iqbrims_institution_settings.html
+++ b/admin/templates/rdm_addons/addons/iqbrims_institution_settings.html
@@ -8,7 +8,7 @@
       <span data-bind="text:properName">{# addon.addon_full_name #}</span>
     </h4>
     <div>
-        <h5>管理プロジェクト</h5>
+        <h5>Management project</h5>
         <div class="management-project" data-bind="if: managementProjectGUID">
             <a class="pull-right text-danger" data-bind="click: removeManagementProject">Remove</a>
             <p class="management-project-guid text-muted"><em data-bind="text: managementProjectGUID"></em></p>
@@ -22,7 +22,7 @@
                                attr: {disabled: !canSaveManagementProject()}"
             >Save</button>
         </div>
-        <h5>組織プロジェクト</h5>
+        <h5>Organizational project</h5>
         <div class="organizational-project" data-bind="if: organizationalProjectGUID">
             <a class="pull-right text-danger" data-bind="click: removeOrganizationalProject">Remove</a>
             <p class="organizational-project-guid text-muted"><em data-bind="text: organizationalProjectGUID"></em></p>


### PR DESCRIPTION
その他のファイルで日本語が使われていないことを確認済み。
（IQB-RIMSのフォルダ名、設定ファイルで指定しているダミーの研究室名、Unicodeのテストを除く）

```
 % git diff remotes/upstream/develop | grep -E "[亜-熙ぁ-んァ-ヶ]"                                   
+REVIEW_FOLDERS = {'paper': u'最終原稿・組図',
+                  'raw': u'生データ',
+                  'checklist': u'チェックリスト',
+                  'scan': u'スキャン結果'}
+LABO_LIST = [{'id': 'rna', 'text': 'RNA分野'},
+             {'id': 'xxx', 'text': 'XXX分野'},
+             {'id': 'yyy', 'text': 'YYY分野'}]
+                u'チェックリスト': ['VISIBLE', 'WRITABLE'],
+                u'スキャン結果': [],
+                u'生データ': ['VISIBLE', 'WRITABLE'],
+                u'最終原稿・組図': ['VISIBLE', 'WRITABLE']
+        name = 'ლ(ಠ益ಠლ).unicode'
+        name = 'ლ(ಠ益ಠლ).unicode'
+        name = 'ლ(ಠ益ಠლ).unicode'
+        name = 'ლ(ಠ益ಠლ).unicode'
```